### PR TITLE
D3ASIM-182 D3ASIM-183 Bug fixes 

### DIFF
--- a/lib/components/Layout/Layout.scss
+++ b/lib/components/Layout/Layout.scss
@@ -2,6 +2,7 @@
 
 .wrapper {
   @extend %base;
+  min-height: 100vh;
 
   img {
     max-width: 100%;

--- a/lib/components/Table/Table.scss
+++ b/lib/components/Table/Table.scss
@@ -12,10 +12,6 @@
     }
   }
 
-  .tableCell {
-    font-weight: 700;
-  }
-
   .tableHeaderCell,
   .tableCell {
     text-align: left;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gsy-component-library",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "reusable components from grid singularity",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- Added min height to layout wrapper style 
- fixes font weight of tables

before:
<img width="1269" alt="d3asimheight_before" src="https://user-images.githubusercontent.com/1789174/37456302-4f848ffa-283f-11e8-9ffc-7b18d06fce79.png">
![d3asimtable_before](https://user-images.githubusercontent.com/1789174/37456307-52693e00-283f-11e8-8d22-6bcdcfdfb466.png)

after:
<img width="1227" alt="d3asimhieght_after" src="https://user-images.githubusercontent.com/1789174/37456315-55c26c7a-283f-11e8-98f6-c04bfe41dc87.png">
![d3asimtable_after](https://user-images.githubusercontent.com/1789174/37456323-5960a8d8-283f-11e8-9cab-12209b00fdbb.png)
