### PR TITLE
D3ASIM-433: refactor native select

### DIFF
--- a/lib/components/Select/Select.js
+++ b/lib/components/Select/Select.js
@@ -18,7 +18,7 @@ const Select = (props) => {
 
   const optionList = options.map(i => (
     <option
-      key={i.id}
+      key={i.value}
       value={i.value}
     >
       {i.option}

--- a/lib/components/Select/Select.js
+++ b/lib/components/Select/Select.js
@@ -58,7 +58,10 @@ const Select = (props) => {
 
 Select.propTypes = {
   className: PropTypes.string,
-  options: PropTypes.instanceOf(Object).isRequired,
+  options: PropTypes.arrayOf(PropTypes.shape({
+    option: PropTypes.string.isRequired,
+    value: PropTypes.string.isRequired,
+  })).isRequired,
   onChange: PropTypes.func,
   onClick: PropTypes.func,
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gsy-component-library",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "reusable components from grid singularity",
   "main": "index.js",
   "scripts": {

--- a/stories/Select.js
+++ b/stories/Select.js
@@ -6,22 +6,18 @@ import { ThemeProvider, Select, Card } from '../lib';
 
 const selectOptions = [
   {
-    id: 1,
     option: 'House 1',
     value: 'house_1',
   },
   {
-    id: 2,
     option: 'House 2',
     value: 'house_2',
   },
   {
-    id: 3,
     option: 'Generator 1',
     value: 'generator_1',
   },
   {
-    id: 4,
     option: 'Fridge 1',
     value: 'fridge_1',
   },


### PR DESCRIPTION
**Who**: @lelith

**What / Why**:  The extra id on the object is not needed as we can use the value to form the unique element key. Also exposes now more detailed the needed PropType for the options array.

![storybook](https://user-images.githubusercontent.com/1789174/40473846-a09a695c-5f3d-11e8-96b7-f0dab059a32c.png)
