### PR TITLE
D3ASIM-450 Chore/Exported components: Export Label component to be used individually

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -16,6 +16,7 @@ import List from './components/List/List';
 import UserStatus from './components/UserStatus/UserStatus';
 import Diamond from './components/Diamond/Diamond';
 import TextInputField from './components/TextInputField/TextInputField';
+import Label from './components/Label/Label';
 
 export {
   ThemeProvider,
@@ -36,4 +37,5 @@ export {
   UserStatus,
   Diamond,
   TextInputField,
+  Label,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gsy-component-library",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gsy-component-library",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "reusable components from grid singularity",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Small change exporting and be able to use the `<Label>` component as an individual component for https://gridsingularity.atlassian.net/browse/D3ASIM-450

**Required for https://github.com/gridsingularity/d3a-ui/pull/80**