### PR TITLE
chore(travis): build pushes only on master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,7 @@ node_js:
 after_success:
   - npm run travis-deploy-once "npm run semantic-release"
 branches:
+  only:
+    - master
   except:
     - /^v\d+\.\d+\.\d+$/


### PR DESCRIPTION
**Who:** @lelith
**What/Why:**
To successfully run semantic-release the merge to master has to trigger a build. Therefore enable on travis "Build pushed branches" and limit branches to master only.