### PR TITLE
D3ASIM-503 Fix/Configuration tree: Prevent error for entities without children (generator & celltower)

### DIFF
--- a/lib/components/TreeView/TreeLeaf.js
+++ b/lib/components/TreeView/TreeLeaf.js
@@ -40,7 +40,7 @@ export default class TreeLeaf extends Component {
   handleClick = () => {
     this.toggleActive();
 
-    if (this.props.refHook) {
+    if (this.props.refHook && this.props.refHook.current) {
       this.props.refHook.current.setInactive();
     }
   }


### PR DESCRIPTION
As generators & cell towers don’t have children don’t trigger `setInactive` on them