### PR TITLE
fix(treeview): leafs did overlap at certain point

### DIFF
--- a/lib/components/TreeView/TreeView.scss
+++ b/lib/components/TreeView/TreeView.scss
@@ -137,8 +137,7 @@
 
     >.treeView__branch--level3 {
       max-width: 300px;
-      max-height: 8000px;
-      overflow: auto;
+      max-height: 10000px;
       transition: max-width 0.8s linear, max-height 0.8s linear;
 
       .treeView__leaf {

--- a/lib/components/TreeView/TreeView.scss
+++ b/lib/components/TreeView/TreeView.scss
@@ -70,7 +70,7 @@
       }
 
       .entryPoint {
-        margin-bottom: -52px;
+        margin-bottom: -56px;
 
         .popOutMenu::after {
           @include themify($themes) {
@@ -137,11 +137,13 @@
 
     >.treeView__branch--level3 {
       max-width: 300px;
-      max-height: 800px;
+      max-height: 8000px;
+      overflow: auto;
       transition: max-width 0.8s linear, max-height 0.8s linear;
 
       .treeView__leaf {
         display: flex;
+        flex-shrink: 0;
         visibility: visible;
         transition: ease-out, visibility 3s 0.5s ease-out;
 


### PR DESCRIPTION
**Who**: @lelith
**What/Why**:
resolves: https://gridsingularity.atlassian.net/browse/D3ASIM-557
- to avoid overlapping in any-case  flex-shrink is disallowed
- set max-height to 10000px instead of 800
- for edgecases, overflow with scrollbar