### PR TITLE
D3ASIM-542 Feat/Scenario tree leafs: Pass active state as props on to children

### DIFF
--- a/lib/components/TreeView/TreeLeaf.js
+++ b/lib/components/TreeView/TreeLeaf.js
@@ -88,6 +88,7 @@ export default class TreeLeaf extends Component {
         {title}
       </span>
     );
+
     const leafDiamond = popOutMenu ? (
       <PopOutMenu
         size={kind}
@@ -110,6 +111,12 @@ export default class TreeLeaf extends Component {
         tabIndex={0}
       />
     );
+
+    const childrenWithProps = React.Children.map(children, child =>
+      React.cloneElement(child, {
+        active: this.state.active,
+        setInactive: this.setInactive,
+      }));
 
     return (
       <div className={leafClasses}>
@@ -138,7 +145,7 @@ export default class TreeLeaf extends Component {
             />
           }
         </div>
-        {children}
+        {childrenWithProps}
       </div>
     );
   }


### PR DESCRIPTION
Pass active state as props on to children in order to toggle child component visibility
(`<DeviceDialog>` component for example)

**Note: Required for https://github.com/gridsingularity/d3a-ui/pull/107**