### PR TITLE
D3ASIM-542 Fix/Configuration-tree: Remove React warnings about added invalid DOM attributes

### DIFF
--- a/lib/components/TreeView/TreeBranch.js
+++ b/lib/components/TreeView/TreeBranch.js
@@ -6,6 +6,8 @@ const TreeBranch = (props) => {
   const {
     className,
     children,
+    active,
+    setInactive,
     ...other
   } = props;
 
@@ -24,11 +26,15 @@ const TreeBranch = (props) => {
 TreeBranch.propTypes = {
   className: PropTypes.string,
   children: PropTypes.node,
+  active: PropTypes.bool,
+  setInactive: PropTypes.func,
 };
 
 TreeBranch.defaultProps = {
   className: '',
   children: undefined,
+  active: false,
+  setInactive: () => {},
 };
 
 export default TreeBranch;


### PR DESCRIPTION
Follow-up to https://github.com/gridsingularity/component-library/pull/79

Since `<TreeView.Branch>` can be a child of `<TreeView.Leaf>` which gets passed `active` (boolean) & `setInactive` (function) as props we need to prevent those props to be added as invalid attributes on DOM elements via `<div {...other}></div>`

More background on this:
https://reactjs.org/blog/2017/09/08/dom-attributes-in-react-16.html#changes-in-detail