### PR TITLE
D3ASIM-566 dialogbox fix

### DIFF
--- a/lib/components/Dialog/Dialog.scss
+++ b/lib/components/Dialog/Dialog.scss
@@ -2,6 +2,10 @@
 
 .dialog {
   width: 340px;
+  position: relative;
+  @include themify($themes) {
+    background-color: themed('darkBg');
+  }
 
   &__close {
     background: none;

--- a/stories/Configuration.js
+++ b/stories/Configuration.js
@@ -3,7 +3,7 @@ import { storiesOf } from '@storybook/react';
 import { withInfo } from '@storybook/addon-info';
 import { action } from '@storybook/addon-actions';
 import StoryRouter from 'storybook-react-router';
-import { Diamond, Hero, Button, ThemeProvider, Layout, Header, TreeView, UserStatus, Card, StepButton, Form, TextInputField, Label, NumberPicker, Select } from '../lib';
+import { Diamond, Hero, Button, ThemeProvider, Layout, Header, TreeView, UserStatus, Card, StepButton, Form, TextInputField, Label, NumberPicker, Dialog, Select } from '../lib';
 import logo from './img/Logo.png';
 
 import IconConfiguration from './img/icon_configuration.svg';
@@ -30,6 +30,13 @@ const selectOptions = [
     value: 'generator_1',
   },
 ];
+
+const dialogboxStyle = {
+  position: 'absolute',
+  left: '-100px',
+  top: '160px',
+  zIndex: '1',
+};
 
 const devices = [
   {
@@ -281,7 +288,16 @@ storiesOf('D3A/Layouts/Configuration', module)
                           numberPicker
                           title="Load"
                           onTitleChange={action('onChange')}
-                        />
+                        >
+                          <Dialog
+                            show
+                            onClose={action('onClick')}
+                            title="Configuration"
+                            style={dialogboxStyle}
+                          >
+                            hello world
+                          </Dialog>
+                        </TreeView.Leaf>
                         <TreeView.Leaf
                           kind="small"
                           type="light"


### PR DESCRIPTION
**Who**: @lelith

**What / Why**: Dialog boxes will often need to overlay other content, therefore its important that they don t have a transparent background.

before:
![dialog](https://user-images.githubusercontent.com/1789174/42038793-1d8b8742-7aec-11e8-8a7f-a7a6223fa99d.png)

after:
![storybook](https://user-images.githubusercontent.com/1789174/42038826-27fc14da-7aec-11e8-8c7f-d10ee689f8be.png)
