### PR TITLE
D3ASIM-567 Fix/RangeSlider component: Extend RangeSlider outside of component

### DIFF
--- a/lib/components/Range/RangeComp.js
+++ b/lib/components/Range/RangeComp.js
@@ -1,9 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import Range from 'rc-slider/lib/Range';
+import { Range, createSliderWithTooltip } from 'rc-slider';
 
-import createSliderWithTooltip from 'rc-slider/lib/createSliderWithTooltip';
+const RangeTooltip = createSliderWithTooltip(Range);
 
 require(`../Slider/Slider.${process.env.NODE_ENV === 'storybook' ? 'scss' : 'css'}`);
 
@@ -31,7 +31,6 @@ const setMarks = (props) => {
 };
 
 const RangeComp = (props) => {
-  const RangeTooltip = createSliderWithTooltip(Range);
   const {
     unit,
     ...other


### PR DESCRIPTION
`<Range>` component needs to be extended w/ `createSliderWithTooltip()` *outside* of the `RangeComp` constructor

Otherwise `RangeTooltip` gets reinstantiated and re-extended every time whenever `<RangeComp` rerenders on state changes (and thus breaks handling of changing range values on the UI)

**Required for https://github.com/gridsingularity/d3a-ui/compare/master...feat/D3ASIM-567_update_device_paramaters_through_dialog_fields**