### PR TITLE
D3ASIM-553 Feat/Button: Add style for disabled button state

### DIFF
--- a/lib/components/Button/Button.scss
+++ b/lib/components/Button/Button.scss
@@ -20,6 +20,10 @@
     }
   }
 
+  &[disabled] {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
 
   &--primary {
     @include themify($themes) {

--- a/stories/Button.js
+++ b/stories/Button.js
@@ -73,4 +73,20 @@ storiesOf('D3A/Atoms/Button', module)
         </div>
       </ThemeProvider>
     )),
+  )
+  .add(
+    'disabled',
+    withInfo(`
+      <Button />
+    `)(() => (
+      <ThemeProvider theme="d3a">
+        <div className="base" style={divStyle}>
+          <Button
+            label="disabled"
+            disabled
+            onClick={action('clicked')}
+          />
+        </div>
+      </ThemeProvider>
+    )),
   );


### PR DESCRIPTION
- [x] Add basic style for `disabled` button state

In the context of https://gridsingularity.atlassian.net/browse/D3ASIM-553 to indicate visually to the user when a configuration is not yet runnable (doesn’t meet minimum constraints for a runnable config)
=> Disables the `Start` button